### PR TITLE
Incorrect resource usage

### DIFF
--- a/src/main/java/com/demo/OidcConfig.java
+++ b/src/main/java/com/demo/OidcConfig.java
@@ -24,7 +24,7 @@ public class OidcConfig {
     void init() {
         try {
             var properties = new Properties();
-            properties.load(getClass().getResourceAsStream("/openid.properties"));
+            properties.load(getClass().getResourceAsStream("/oidc.properties"));
             domain = properties.getProperty("domain");
             clientId = properties.getProperty("clientId");
             clientSecret = properties.getProperty("clientSecret");


### PR DESCRIPTION
The OidcConfig bean cannot be initialized as the PostConstruct init method is not able to resolve the resource openid.properties, it has to be oidc.properties.

Launching the server with incorrect properties would result in below exception, (when accessing http://localhost:8080/protected)

Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.jboss.weld.core@5.1.0.Final//org.jboss.weld.injection.producer.DefaultLifecycleCallbackInvoker.invokeMethods(DefaultLifecycleCallbackInvoker.java:83)
	... 91 more
Caused by: java.lang.NullPointerException: inStream parameter is null
	at java.base/java.util.Objects.requireNonNull(Objects.java:246)
	at java.base/java.util.Properties.load(Properties.java:407)
	at deployment.jakarta-ee-oidc-example.war//com.demo.OidcConfig.init(OidcConfig.java:27)
	... 96 more